### PR TITLE
Add persistent Q-learning

### DIFF
--- a/main_qai.py
+++ b/main_qai.py
@@ -1,13 +1,15 @@
 
 import tkinter as tk
+import argparse
+import os
 from game import Game
 from simple_ai_qlearn import SimpleAIQ
 
 class GameUI:
-    def __init__(self, root):
+    def __init__(self, root, qtable_path='qtable.pkl'):
         self.root = root
         self.game = Game()
-        self.ai = SimpleAIQ('qtable.pkl')
+        self.ai = SimpleAIQ(qtable_path)
         self.auto_job = None
 
         self.root.title("2048 Q学習AI")
@@ -76,6 +78,13 @@ class GameUI:
         self.score_label.config(text='Score: {}'.format(self.game.score))
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Play 2048 with a Q-learning AI')
+    parser.add_argument('--qtable', default='qtable.pkl', help='path to Q-table file')
+    args = parser.parse_args()
+
+    if not os.path.exists(args.qtable):
+        print(f'Q-table file {args.qtable} not found. Run qlearning.py first to train.')
+
     root = tk.Tk()
-    ui = GameUI(root)
+    ui = GameUI(root, qtable_path=args.qtable)
     root.mainloop()

--- a/qlearning.py
+++ b/qlearning.py
@@ -1,6 +1,8 @@
 ### ファイル: qlearning_ai.py
 import pickle
 import random
+import os
+import argparse
 from game import Game
 
 ACTIONS = ['Up', 'Down', 'Left', 'Right']
@@ -31,7 +33,12 @@ def update_q(q_table, state, action, reward, next_state, alpha, gamma):
     q_table[(state, action)] = old + alpha * (reward + gamma * max_next - old)
 
 def train_q_learning(episodes=1000, epsilon=0.1, alpha=0.1, gamma=0.9, save_path='qtable.pkl'):
-    q_table = {}
+    if os.path.exists(save_path):
+        with open(save_path, 'rb') as f:
+            q_table = pickle.load(f)
+        print(f"Loaded existing Q-table from {save_path}")
+    else:
+        q_table = {}
     for ep in range(1, episodes + 1):
         game = Game()
         state = normalize_state(game.get_state())
@@ -83,3 +90,21 @@ class QAI:
 
 # 学習はコマンドで: python qlearning_ai.py --episodes 5000 など
 # その後に main.py を起動すれば、GUIで Q 学習済み AI がプレイします。
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Train 2048 Q-learning AI')
+    parser.add_argument('--episodes', type=int, default=1000,
+                        help='number of training episodes')
+    parser.add_argument('--epsilon', type=float, default=0.1,
+                        help='epsilon for epsilon-greedy')
+    parser.add_argument('--alpha', type=float, default=0.1,
+                        help='learning rate')
+    parser.add_argument('--gamma', type=float, default=0.9,
+                        help='discount factor')
+    parser.add_argument('--qtable', default='qtable.pkl',
+                        help='path to save/load Q-table')
+    args = parser.parse_args()
+
+    train_q_learning(episodes=args.episodes, epsilon=args.epsilon,
+                     alpha=args.alpha, gamma=args.gamma,
+                     save_path=args.qtable)

--- a/simple_ai_qlearn.py
+++ b/simple_ai_qlearn.py
@@ -1,12 +1,16 @@
 
 import pickle
+import os
 
 ACTIONS = ['Up', 'Down', 'Left', 'Right']
 
 class SimpleAIQ:
     def __init__(self, qtable_path='qtable.pkl'):
-        with open(qtable_path, 'rb') as f:
-            self.q_table = pickle.load(f)
+        if os.path.exists(qtable_path):
+            with open(qtable_path, 'rb') as f:
+                self.q_table = pickle.load(f)
+        else:
+            self.q_table = {}
 
     def normalize_state(self, board):
         def rotate(b): return [list(row) for row in zip(*b[::-1])]


### PR DESCRIPTION
## Summary
- allow continuing training by loading existing qtables
- add command line interface for qlearning script
- permit Q-table location to be specified in main_qai
- gracefully load non-existent qtables

## Testing
- `python -m py_compile game.py qlearning.py simple_ai_qlearn.py main_qai.py`
- `python qlearning.py --episodes 1 --qtable test_qtable.pkl`
- `python qlearning.py --episodes 1 --qtable test_qtable.pkl`

------
https://chatgpt.com/codex/tasks/task_e_68441642436c8328aa501f95ff4748a2